### PR TITLE
Fix unhandled check condition...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+bin/
+
+*.backup

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -26,6 +26,8 @@ func Check(client v1.API, query string, ts time.Time) (ans bool, err error) {
 		}
 		if boolVector[0].Value == 1 {
 			return true, nil
+		} else {
+		    return false, nil
 		}
 	}
 	return false, errors.New("return type is not model.ValVector")


### PR DESCRIPTION
When rule failed, metrics-checker raise `Metrics checker running error` instead of `Rule failed`.

Because a false condition remain unhandled in `prometheus.go:Check`. Fix this...