### PR TITLE
proposal: return failed when a rule is satisfied

### DIFF
--- a/pkg/metrics/checker.go
+++ b/pkg/metrics/checker.go
@@ -55,7 +55,7 @@ func (m *Checker) Run() error {
 				// TODO: I'm not sure whether Run() should return a error or not.
 				return err
 			}
-			if ans == false {
+			if ans == true {
 				// Alert function is required.
 				rule.AlertFunc(rule)
 			}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -19,16 +19,16 @@ func Check(client v1.API, query string, ts time.Time) (ans bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	if val.Type() == model.ValVector {
-		boolVector := val.(model.Vector)
-		if boolVector.Len() == 0 {
-			return false, errors.New("Prometheus is not up")
-		}
-		if boolVector[0].Value == 1 {
+	// Ref: https://github.com/prometheus/prometheus/blob/76750d2a96df54226e85ac272d7ad5a547630240/rules/manager.go#L186-L206
+	switch v := val.(type) {
+	case model.Vector:
+		if v.Len() > 0 {
 			return true, nil
 		}
+		return false, nil
+	default:
+		return false, errors.New("rule result is not a vector")
 	}
-	return false, errors.New("return type is not model.ValVector")
 }
 
 // AddHTTPIfIP add "http://" before ip address like 127.0.0.1 or 127.0.0.1:3000

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -22,14 +22,11 @@ func Check(client v1.API, query string, ts time.Time) (ans bool, err error) {
 	// Ref: https://github.com/prometheus/prometheus/blob/76750d2a96df54226e85ac272d7ad5a547630240/rules/manager.go#L186-L206
 	switch v := val.(type) {
 	case model.Vector:
-		if v.Len() > 0 {
-			return true, nil
-		} else {
-		    return false, nil
-		}
-		return false, nil
+		return v.Len() > 0, nil
+	case *model.Scalar:
+		return v != nil, nil
 	default:
-		return false, errors.New("rule result is not a vector")
+		return false, errors.New("rule result is not a vector or scalar")
 	}
 }
 

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -19,18 +19,18 @@ func Check(client v1.API, query string, ts time.Time) (ans bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	if val.Type() == model.ValVector {
-		boolVector := val.(model.Vector)
-		if boolVector.Len() == 0 {
-			return false, errors.New("Prometheus is not up")
-		}
-		if boolVector[0].Value == 1 {
+	// Ref: https://github.com/prometheus/prometheus/blob/76750d2a96df54226e85ac272d7ad5a547630240/rules/manager.go#L186-L206
+	switch v := val.(type) {
+	case model.Vector:
+		if v.Len() > 0 {
 			return true, nil
 		} else {
 		    return false, nil
 		}
+		return false, nil
+	default:
+		return false, errors.New("rule result is not a vector")
 	}
-	return false, errors.New("return type is not model.ValVector")
 }
 
 // AddHTTPIfIP add "http://" before ip address like 127.0.0.1 or 127.0.0.1:3000

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -19,15 +19,14 @@ func Check(client v1.API, query string, ts time.Time) (ans bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	// Ref: https://github.com/prometheus/prometheus/blob/76750d2a96df54226e85ac272d7ad5a547630240/rules/manager.go#L186-L206
+	// Ref: https://github.com/prom[<8;52;14metheus/prometheus/blob/76750d2a96df54226e85ac272d7ad5a547630240/rules/manager.go#L186-L206
 	switch v := val.(type) {
 	case model.Vector:
-		if v.Len() > 0 {
-			return true, nil
-		}
-		return false, nil
+		return v.Len() > 0, nil
+	case *model.Scalar:
+		return v != nil, nil
 	default:
-		return false, errors.New("rule result is not a vector")
+		return false, errors.New("rule result is not a vector or scalar")
 	}
 }
 


### PR DESCRIPTION
**Clean code**
- [x] Use golang [type switch](https://tour.golang.org/methods/16) instead of checking val type with `==`

**Changes**
- [x] Before, we send alerts when a rule **is not** satisfied.
   After this PR, we send alerts when a  rule **is** satisfied, which is similarly as prometheus alerting rules.
- [x] Before, a query must return bool, and true means that a rule is satisfied. 
   After this PR, a query can return a vector (or a scalar), and nonempty vector means satisfied. 
   
   IMO, this simplifies the promql. For example, we want to use metrics-checker to check whether a tikv is restarted recently. Before, we write a query like this: 
    ```
    sum(process_start_time_seconds{tidb_cluster="", job="tikv"}) == bool 
    sum(process_start_time_seconds{tidb_cluster="", job="tikv"} offset 2m)
    ```
    Currently, we can write the query like the following(the above query also works well.)
    ```
    rate(process_start_time_seconds{tidb_cluster="", job="tikv"}[1m]) != 0
    ```

A config.yaml to test this PR
```yaml
start-after: 0s
interval: 10s
rules:
    - tag: uptime
      promql: rate(process_start_time_seconds{tidb_cluster="", job="tikv"}[1m]) != 0
```

**TODO**
- [ ] Change examples if this proposal is ok